### PR TITLE
Changed $all_widgets from string to array.

### DIFF
--- a/parts/admin-pages/system.php
+++ b/parts/admin-pages/system.php
@@ -84,7 +84,7 @@ function piklist_site_inventory()
   }
 
   // Widgets
-  $all_widgets = '';
+  $all_widgets = array();
   $sidebar_widgets = '';
   $current_sidebar = '';
   $active_widgets = get_option('sidebars_widgets');


### PR DESCRIPTION
Variable $all_widgets was declared as a string but used as an array causing this error: Uncaught Error: [] operator not supported for strings.